### PR TITLE
Fix react/material toggle button position

### DIFF
--- a/src/components/basic/Badge/BadgeComponent.css
+++ b/src/components/basic/Badge/BadgeComponent.css
@@ -1,26 +1,31 @@
 @import url('https://maxcdn.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css');
 @import url('https://cdn.jsdelivr.net/npm/gijgo@1.9.10/css/gijgo.min.css');
 
-.btnCompoWrap{
+.btnCompoWrap {
   display: flex;
   flex-direction: column;
   margin-left: 320px;
   margin-top: 60px;
 }
-.btn-title{
+
+.btn-title {
   margin: 10px 0 20px;
   font-weight: 700;
   text-align: left;
   font-size: 18px;
 }
+
 .step-tabs-wrapper {
   width: 885px;
-  border: 1px solid rgba(0,0,0,.125);
+  border: 1px solid rgba(0, 0, 0, .125);
   border-radius: 6px;
   margin-bottom: 60px;
   margin-left: -7px;
+  position: relative;
 }
-badge#code-demo-tab-tab-demo, badge#code-demo-tab-tab-code {
+
+badge#code-demo-tab-tab-demo,
+badge#code-demo-tab-tab-code {
   border-bottom: 1px solid #dee2e6;
   min-width: 130px;
   text-align: center;
@@ -29,24 +34,31 @@ badge#code-demo-tab-tab-demo, badge#code-demo-tab-tab-code {
   background: #fff;
   color: #000;
 }
-badge#code-demo-tab-tab-demo.active, badge#code-demo-tab-tab-code.active {
+
+badge#code-demo-tab-tab-demo.active,
+badge#code-demo-tab-tab-code.active {
   color: #000;
   opacity: 1 !important;
   font-weight: 700;
   background: #f5f5f5;
 }
-badge#code-demo-tab-tab-demo.active:hover, badge#code-demo-tab-tab-code.active:hover  {
-  background-color:#fff;
+
+badge#code-demo-tab-tab-demo.active:hover,
+badge#code-demo-tab-tab-code.active:hover {
+  background-color: #fff;
   transition: 0.7s;
 }
+
 .demo-wrapper {
   text-align: left;
   margin-top: 15px;
   margin-left: 25px;
 }
+
 .compo-description {
   margin-top: 25px;
 }
+
 .jsx-code-wrapper {
   margin-top: 20px;
   margin-left: 20px;

--- a/src/components/basic/Badge/BadgeComponent.js
+++ b/src/components/basic/Badge/BadgeComponent.js
@@ -14,11 +14,11 @@ function BadgeComponent(props) {
   return (
     <div className='btnCompoWrap'>
       <h3 className='btn-title'>Badge</h3>
-      <ToggleView
-        onChange={handleChange}
-        isViewResized={props.isViewResized}
-      />
       <div className='step-tabs-wrapper'>
+        <ToggleView
+          onChange={handleChange}
+          isViewResized={props.isViewResized}
+        />
         <Tabs defaultActiveKey="demo" id="code-demo-tab">
           <Tab eventKey="demo" title="Demo">
             {!matview ? <RbBadge /> : <MatBadge />}

--- a/src/components/basic/Button/ButtonComponent.css
+++ b/src/components/basic/Button/ButtonComponent.css
@@ -1,26 +1,31 @@
 @import url('https://maxcdn.bootstrapcdn.com/bootstrap/4.4.1/css/bootstrap.min.css');
 @import url('https://cdn.jsdelivr.net/npm/gijgo@1.9.10/css/gijgo.min.css');
 
-.btnCompoWrap{
+.btnCompoWrap {
   display: flex;
   flex-direction: column;
   margin-left: 320px;
   margin-top: 60px;
 }
-.btn-title{
+
+.btn-title {
   margin: 10px 0 20px;
   font-weight: 700;
   text-align: left;
   font-size: 18px;
 }
+
 .step-tabs-wrapper {
   width: 885px;
-  border: 1px solid rgba(0,0,0,.125);
+  border: 1px solid rgba(0, 0, 0, .125);
   border-radius: 6px;
   margin-bottom: 60px;
   margin-left: -7px;
+  position: relative;
 }
-button#code-demo-tab-tab-demo, button#code-demo-tab-tab-code {
+
+button#code-demo-tab-tab-demo,
+button#code-demo-tab-tab-code {
   border-bottom: 1px solid #dee2e6;
   min-width: 130px;
   text-align: center;
@@ -29,24 +34,31 @@ button#code-demo-tab-tab-demo, button#code-demo-tab-tab-code {
   background: #fff;
   color: #000;
 }
-button#code-demo-tab-tab-demo.active, button#code-demo-tab-tab-code.active {
+
+button#code-demo-tab-tab-demo.active,
+button#code-demo-tab-tab-code.active {
   color: #000;
   opacity: 1 !important;
   font-weight: 700;
   background: #f5f5f5;
 }
-button#code-demo-tab-tab-demo.active:hover, button#code-demo-tab-tab-code.active:hover  {
-  background-color:#fff;
+
+button#code-demo-tab-tab-demo.active:hover,
+button#code-demo-tab-tab-code.active:hover {
+  background-color: #fff;
   transition: 0.7s;
 }
+
 .demo-wrapper {
   text-align: left;
   margin-top: 15px;
   margin-left: 25px;
 }
+
 .compo-description {
   margin-top: 25px;
 }
+
 .jsx-code-wrapper {
   margin-top: 20px;
   margin-left: 20px;

--- a/src/components/basic/Button/ButtonComponent.js
+++ b/src/components/basic/Button/ButtonComponent.js
@@ -14,11 +14,11 @@ function ButtonComponent(props) {
   return (
     <div className='btnCompoWrap'>
       <h3 className='btn-title'>Button</h3>
-      <ToggleView
-        onChange={handleChange}
-        isViewResized={props.isViewResized}
-      />
       <div className='step-tabs-wrapper'>
+        <ToggleView
+          onChange={handleChange}
+          isViewResized={props.isViewResized}
+        />
         <Tabs defaultActiveKey="demo" id="code-demo-tab">
           <Tab eventKey="demo" title="Demo">
             {!matview ? <RbButton /> : <MatButton />}

--- a/src/components/basic/ButtonGroup/ButtonGroupComponent.js
+++ b/src/components/basic/ButtonGroup/ButtonGroupComponent.js
@@ -13,11 +13,11 @@ function ButtonGroupComponent(props) {
   return (
     <div className='btnCompoWrap'>
       <h3 className='btn-title'>Button Group</h3>
-      <ToggleView
-        onChange={handleChange}
-        isViewResized={props.isViewResized}
-      />
       <div className='step-tabs-wrapper'>
+        <ToggleView
+          onChange={handleChange}
+          isViewResized={props.isViewResized}
+        />
         <Tabs defaultActiveKey="demo" id="code-demo-tab">
           <Tab eventKey="demo" title="Demo">
             {!matview ? <RbButtonGroup /> : <MatButtonGroup />}

--- a/src/components/basic/Dropdown/DropDownComponent.js
+++ b/src/components/basic/Dropdown/DropDownComponent.js
@@ -7,23 +7,23 @@ import Tab from 'react-bootstrap/Tab';
 import './DropDownComponent.css';
 
 function DropDownComponent(props) {
-  const [ matview, setMatview ] = useState(false);
-  useEffect(()=> window.scrollTo(0,0));
-  
+  const [matview, setMatview] = useState(false);
+  useEffect(() => window.scrollTo(0, 0));
+
   return (
     <div className='btnCompoWrap'>
       <h3 className='btn-title'>Dropdown</h3>
-      <ToggleView 
-        onChange={(ev) => (ev === 'react') ? setMatview(false) : setMatview(true)}
-        isViewResized={props.isViewResized}
-      />
       <div className='step-tabs-wrapper'>
+        <ToggleView
+          onChange={(ev) => (ev === 'react') ? setMatview(false) : setMatview(true)}
+          isViewResized={props.isViewResized}
+        />
         <Tabs defaultActiveKey="demo" id="code-demo-tab">
           <Tab eventKey="demo" title="Demo">
-            {!matview ? <RbDropdown /> : <MatDropdown/>}
+            {!matview ? <RbDropdown /> : <MatDropdown />}
           </Tab>
           <Tab eventKey="code" title="Code">
-            {!matview ? <RbDropdownCode /> : <MatDropdownCode/>}
+            {!matview ? <RbDropdownCode /> : <MatDropdownCode />}
           </Tab>
         </Tabs>
       </div>

--- a/src/components/basic/Image/ImageComponent.js
+++ b/src/components/basic/Image/ImageComponent.js
@@ -13,14 +13,14 @@ function ImageComponent(props) {
   return (
     <div className='btnCompoWrap'>
       <h3 className='btn-title'>Image</h3>
-      <ToggleView
-        onChange={handleChange}
-        isViewResized={props.isViewResized}
-      />
       <div className='step-tabs-wrapper'>
+        <ToggleView
+          onChange={handleChange}
+          isViewResized={props.isViewResized}
+        />
         <Tabs defaultActiveKey="demo" id="code-demo-tab">
           <Tab eventKey="demo" title="Demo">
-            {!matview ? <RbImage /> : <MatImage/>}
+            {!matview ? <RbImage /> : <MatImage />}
           </Tab>
           <Tab eventKey="code" title="Code">
             {!matview ? <RbImageCode /> : <MatImageCode />}

--- a/src/components/basic/Input/InputComponent.js
+++ b/src/components/basic/Input/InputComponent.js
@@ -8,27 +8,27 @@ import '../Button/ButtonComponent.css';
 import './InputComponent.css';
 
 function InputComponent(props) {
-    const [ matview, setMatview ] = useState(false);
-    useEffect(()=> window.scrollTo(0,0));
-    return (
-      <div className='btnCompoWrap'>
-        <h3 className='btn-title'>Input</h3>
-        <ToggleView 
+  const [matview, setMatview] = useState(false);
+  useEffect(() => window.scrollTo(0, 0));
+  return (
+    <div className='btnCompoWrap'>
+      <h3 className='btn-title'>Input</h3>
+      <div className='step-tabs-wrapper'>
+        <ToggleView
           onChange={(ev) => (ev === 'react') ? setMatview(false) : setMatview(true)}
           isViewResized={props.isViewResized}
         />
-        <div className='step-tabs-wrapper'>
-          <Tabs defaultActiveKey="demo" id="code-demo-tab">
-            <Tab eventKey="demo" title="Demo">
-             {!matview ? <RbInput /> : <MatInput/>}
-            </Tab>
-            <Tab eventKey="code" title="Code">
-              { !matview ? <RbInputCode />: <MatInputCode /> }
-            </Tab>
-          </Tabs>
-        </div>
+        <Tabs defaultActiveKey="demo" id="code-demo-tab">
+          <Tab eventKey="demo" title="Demo">
+            {!matview ? <RbInput /> : <MatInput />}
+          </Tab>
+          <Tab eventKey="code" title="Code">
+            {!matview ? <RbInputCode /> : <MatInputCode />}
+          </Tab>
+        </Tabs>
       </div>
-    );
+    </div>
+  );
 }
 
 export default InputComponent;

--- a/src/components/basic/ListGroup/ListGroupComponent.js
+++ b/src/components/basic/ListGroup/ListGroupComponent.js
@@ -7,23 +7,23 @@ import Tab from 'react-bootstrap/Tab';
 // import './ListGroupComponent.css';
 
 function ListGroupComponent(props) {
-  const [ matview, setMatview ] = useState(false);
-  useEffect(()=> window.scrollTo(0,0));
-  
+  const [matview, setMatview] = useState(false);
+  useEffect(() => window.scrollTo(0, 0));
+
   return (
     <div className='btnCompoWrap'>
       <h3 className='btn-title'>ListGroup</h3>
-      <ToggleView 
-        onChange={(ev) => (ev === 'react') ? setMatview(false) : setMatview(true)}
-        isViewResized={props.isViewResized}
-      />
       <div className='step-tabs-wrapper'>
+        <ToggleView
+          onChange={(ev) => (ev === 'react') ? setMatview(false) : setMatview(true)}
+          isViewResized={props.isViewResized}
+        />
         <Tabs defaultActiveKey="demo" id="code-demo-tab">
           <Tab eventKey="demo" title="Demo">
-            {!matview ? <RbListGroup /> : <MatListGroup/>}
+            {!matview ? <RbListGroup /> : <MatListGroup />}
           </Tab>
           <Tab eventKey="code" title="Code">
-            {!matview ? <RbListGroupCode /> : <MatListGroupCode/>}
+            {!matview ? <RbListGroupCode /> : <MatListGroupCode />}
           </Tab>
         </Tabs>
       </div>

--- a/src/components/basic/NavigationBar/NavBarComponent.js
+++ b/src/components/basic/NavigationBar/NavBarComponent.js
@@ -7,23 +7,23 @@ import Tab from 'react-bootstrap/Tab';
 
 
 function NavBarComponent(props) {
-  const [ matview, setMatview ] = useState(false);
-  useEffect(()=> window.scrollTo(0,0));
-  
+  const [matview, setMatview] = useState(false);
+  useEffect(() => window.scrollTo(0, 0));
+
   return (
     <div className='btnCompoWrap'>
       <h3 className='btn-title'>Navigation Bar</h3>
-      <ToggleView 
-        onChange={(ev) => (ev === 'react') ? setMatview(false) : setMatview(true)}
-        isViewResized={props.isViewResized}
-      />
       <div className='step-tabs-wrapper'>
+        <ToggleView
+          onChange={(ev) => (ev === 'react') ? setMatview(false) : setMatview(true)}
+          isViewResized={props.isViewResized}
+        />
         <Tabs defaultActiveKey="demo" id="code-demo-tab">
           <Tab eventKey="demo" title="Demo">
-            {!matview ? <RbNavBar /> : <MatNavBar/>}
+            {!matview ? <RbNavBar /> : <MatNavBar />}
           </Tab>
           <Tab eventKey="code" title="Code">
-            {!matview ? <RbNavBarCode /> : <MatNavBarCode/>}
+            {!matview ? <RbNavBarCode /> : <MatNavBarCode />}
           </Tab>
         </Tabs>
       </div>

--- a/src/components/basic/RadioAndCheckBox/RadioButtonComponent.js
+++ b/src/components/basic/RadioAndCheckBox/RadioButtonComponent.js
@@ -6,22 +6,22 @@ import Tabs from 'react-bootstrap/Tabs'
 import Tab from 'react-bootstrap/Tab';
 
 function RadioButtonComponent(props) {
-  const [ matview, setMatview ] = useState(false);
-  useEffect(()=> window.scrollTo(0,0));
+  const [matview, setMatview] = useState(false);
+  useEffect(() => window.scrollTo(0, 0));
   return (
     <div className='btnCompoWrap'>
       <h3 className='btn-title'>{`Radio & Checkbox`}</h3>
-      <ToggleView 
-        onChange={(ev) => (ev === 'react') ? setMatview(false) : setMatview(true)}
-        isViewResized={props.isViewResized}
-      />
       <div className='step-tabs-wrapper'>
+        <ToggleView
+          onChange={(ev) => (ev === 'react') ? setMatview(false) : setMatview(true)}
+          isViewResized={props.isViewResized}
+        />
         <Tabs defaultActiveKey="demo" id="code-demo-tab">
           <Tab eventKey="demo" title="Demo">
-            {!matview ? <RbRadio/> : <MatRadio />}
+            {!matview ? <RbRadio /> : <MatRadio />}
           </Tab>
           <Tab eventKey="code" title="Code">
-           {!matview ? <RbRadioCode/> : <MatRadioCode/>} 
+            {!matview ? <RbRadioCode /> : <MatRadioCode />}
           </Tab>
         </Tabs>
       </div>

--- a/src/components/basic/ToggleButton/ToggleButtonComponent.js
+++ b/src/components/basic/ToggleButton/ToggleButtonComponent.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect }from 'react';
+import React, { useState, useEffect } from 'react';
 import ToggleView from '../../util/ToggleView';
 import { RbToggle, RbToggleCode } from './RbToggle';
 import { MatToggle, MatToggleCode } from './MatToggle';
@@ -7,22 +7,22 @@ import Tab from 'react-bootstrap/Tab';
 
 
 function ToggleButtonComponent(props) {
-  const [ matview, setMatview ] = useState(false);
-  useEffect(()=> window.scrollTo(0,0));
+  const [matview, setMatview] = useState(false);
+  useEffect(() => window.scrollTo(0, 0));
   return (
     <div className='btnCompoWrap'>
       <h3 className='btn-title'>Toggle Button</h3>
-      <ToggleView 
-        onChange={(ev) => (ev === 'react') ? setMatview(false) : setMatview(true)}
-        isViewResized={props.isViewResized}
-      />
       <div className='step-tabs-wrapper'>
+        <ToggleView
+          onChange={(ev) => (ev === 'react') ? setMatview(false) : setMatview(true)}
+          isViewResized={props.isViewResized}
+        />
         <Tabs defaultActiveKey="demo" id="code-demo-tab">
           <Tab eventKey="demo" title="Demo">
-            {!matview ? <RbToggle/> : <MatToggle />}
+            {!matview ? <RbToggle /> : <MatToggle />}
           </Tab>
           <Tab eventKey="code" title="Code">
-            {!matview ? <RbToggleCode /> : <MatToggleCode/>}
+            {!matview ? <RbToggleCode /> : <MatToggleCode />}
           </Tab>
         </Tabs>
       </div>

--- a/src/components/overlay/Modal/ModalComponent.js
+++ b/src/components/overlay/Modal/ModalComponent.js
@@ -6,22 +6,22 @@ import Tabs from 'react-bootstrap/Tabs'
 import Tab from 'react-bootstrap/Tab';
 
 function ModalComponent(props) {
-  const [ matview, setMatview ] = useState(false);
-  useEffect(()=> window.scrollTo(0,0));
+  const [matview, setMatview] = useState(false);
+  useEffect(() => window.scrollTo(0, 0));
   return (
     <div className='btnCompoWrap'>
       <h3 className='btn-title'>Modal</h3>
-      <ToggleView 
-        onChange={(ev) => (ev === 'react') ? setMatview(false) : setMatview(true)}
-        isViewResized={props.isViewResized}  
-      />
       <div className='step-tabs-wrapper'>
+        <ToggleView
+          onChange={(ev) => (ev === 'react') ? setMatview(false) : setMatview(true)}
+          isViewResized={props.isViewResized}
+        />
         <Tabs defaultActiveKey="demo" id="code-demo-tab">
           <Tab eventKey="demo" title="Demo">
-            {!matview ? <RbModal/> : <MatModal />}
+            {!matview ? <RbModal /> : <MatModal />}
           </Tab>
           <Tab eventKey="code" title="Code">
-            {!matview ? <RbModalCode/> : <MatModalCode/>}
+            {!matview ? <RbModalCode /> : <MatModalCode />}
           </Tab>
         </Tabs>
       </div>

--- a/src/components/overlay/Popover/PopoverComponent.js
+++ b/src/components/overlay/Popover/PopoverComponent.js
@@ -7,23 +7,23 @@ import Tab from 'react-bootstrap/Tab';
 
 
 function PopoverComponent(props) {
-  const [ matview, setMatview ] = useState(false);
-  useEffect(()=> window.scrollTo(0,0),[]);
+  const [matview, setMatview] = useState(false);
+  useEffect(() => window.scrollTo(0, 0), []);
 
   return (
     <div className='btnCompoWrap'>
       <h3 className='btn-title'>Popover</h3>
-      <ToggleView 
-        onChange={(ev) => (ev === 'react') ? setMatview(false) : setMatview(true)}
-        isViewResized={props.isViewResized}
-      />
       <div className='step-tabs-wrapper'>
+        <ToggleView
+          onChange={(ev) => (ev === 'react') ? setMatview(false) : setMatview(true)}
+          isViewResized={props.isViewResized}
+        />
         <Tabs defaultActiveKey="demo" id="code-demo-tab">
           <Tab eventKey="demo" title="Demo">
-            {!matview ? <RbPopover/> : <MatPopover/>}
+            {!matview ? <RbPopover /> : <MatPopover />}
           </Tab>
           <Tab eventKey="code" title="Code">
-            {!matview ? <RbPopoverCode/> : <MatPopoverCode/>}
+            {!matview ? <RbPopoverCode /> : <MatPopoverCode />}
           </Tab>
         </Tabs>
       </div>

--- a/src/components/overlay/Tooltip/TooltipComponent.js
+++ b/src/components/overlay/Tooltip/TooltipComponent.js
@@ -6,23 +6,23 @@ import Tabs from 'react-bootstrap/Tabs'
 import Tab from 'react-bootstrap/Tab';
 
 function TooltipComponent(props) {
-  const [ matview, setMatview ] = useState(false);
-  useEffect(()=> window.scrollTo(0,0));
+  const [matview, setMatview] = useState(false);
+  useEffect(() => window.scrollTo(0, 0));
 
   return (
     <div className='btnCompoWrap'>
       <h3 className='btn-title'>Tooltip</h3>
-      <ToggleView 
-        onChange={(ev) => (ev === 'react') ? setMatview(false) : setMatview(true)}
-        isViewResized={props.isViewResized}
-      />
       <div className='step-tabs-wrapper'>
+        <ToggleView
+          onChange={(ev) => (ev === 'react') ? setMatview(false) : setMatview(true)}
+          isViewResized={props.isViewResized}
+        />
         <Tabs defaultActiveKey="demo" id="code-demo-tab">
           <Tab eventKey="demo" title="Demo">
-            {!matview ? <RbTooltip/> : <MatTooltip />}
+            {!matview ? <RbTooltip /> : <MatTooltip />}
           </Tab>
           <Tab eventKey="code" title="Code">
-            {!matview ? <RbTooltipCode/> : <MatTooltipCode/>}
+            {!matview ? <RbTooltipCode /> : <MatTooltipCode />}
           </Tab>
         </Tabs>
       </div>

--- a/src/components/tables/ApiDataTable/ApiDataTableComponent.js
+++ b/src/components/tables/ApiDataTable/ApiDataTableComponent.js
@@ -11,13 +11,13 @@ const ApiDataTableComponent = (props) => {
   return (
     <div className="btnCompoWrap">
       <h3 className="btn-title">Dynamic Data Table ( API Data )</h3>
-      <ToggleView
-        onChange={(ev) =>
-          ev === "react" ? setMatview(false) : setMatview(true)
-        }
-        isViewResized={props.isViewResized}
-      />
       <div className="step-tabs-wrapper">
+        <ToggleView
+          onChange={(ev) =>
+            ev === "react" ? setMatview(false) : setMatview(true)
+          }
+          isViewResized={props.isViewResized}
+        />
         <Tabs defaultActiveKey="demo" id="code-demo-tab">
           <Tab eventKey="demo" title="Demo">
             {!matview ? <RbAPITable /> : <MatAPITable />}

--- a/src/components/tables/EditableTable/EditableTableComponent.js
+++ b/src/components/tables/EditableTable/EditableTableComponent.js
@@ -1,28 +1,28 @@
 import React, { useEffect, useState } from 'react';
 import ToggleView from '../../util/ToggleView';
 import { RbEditableTable, RbEditableTableCode } from './RbEditableTable'
-import {  MatEditableTable,  MatEditableTableCode } from './MatEditableTable';
+import { MatEditableTable, MatEditableTableCode } from './MatEditableTable';
 import Tabs from 'react-bootstrap/Tabs'
 import Tab from 'react-bootstrap/Tab';
 
-const EditableTableComponent = (props)=> {
-  const [ matview, setMatview ] = useState(false);
-  useEffect(()=> window.scrollTo(0,0));
+const EditableTableComponent = (props) => {
+  const [matview, setMatview] = useState(false);
+  useEffect(() => window.scrollTo(0, 0));
 
   return (
     <div className='btnCompoWrap'>
       <h3 className='btn-title'>CRUD Table</h3>
-      <ToggleView 
-        onChange={(ev) => (ev === 'react') ? setMatview(false) : setMatview(true)}
-        isViewResized={props.isViewResized}
-      />
       <div className='step-tabs-wrapper'>
+        <ToggleView
+          onChange={(ev) => (ev === 'react') ? setMatview(false) : setMatview(true)}
+          isViewResized={props.isViewResized}
+        />
         <Tabs defaultActiveKey="demo" id="code-demo-tab">
           <Tab eventKey="demo" title="Demo">
-            {!matview ? <RbEditableTable/> : <MatEditableTable />}
+            {!matview ? <RbEditableTable /> : <MatEditableTable />}
           </Tab>
           <Tab eventKey="code" title="Code">
-            {!matview ? <RbEditableTableCode/> : <MatEditableTableCode/>}
+            {!matview ? <RbEditableTableCode /> : <MatEditableTableCode />}
           </Tab>
         </Tabs>
       </div>

--- a/src/components/tables/ExportExcelTable/ExportExcelComponent.js
+++ b/src/components/tables/ExportExcelTable/ExportExcelComponent.js
@@ -12,13 +12,13 @@ const ExportExcelComponent = (props) => {
     return (
         <div className="btnCompoWrap">
             <h3 className="btn-title">Export Excel Table</h3>
-            <ToggleView
-                onChange={(ev) =>
-                    ev === "react" ? setMatview(false) : setMatview(true)
-                }
-                isViewResized={props.isViewResized}
-            />
             <div className="step-tabs-wrapper">
+                <ToggleView
+                    onChange={(ev) =>
+                        ev === "react" ? setMatview(false) : setMatview(true)
+                    }
+                    isViewResized={props.isViewResized}
+                />
                 <Tabs defaultActiveKey="demo" id="code-demo-tab">
                     <Tab eventKey="demo" title="Demo">
                         {!matview ? <RbExportExcel /> : <MatExportExcel />}

--- a/src/components/tables/ExportPdfTable/ExportPdfComponent.js
+++ b/src/components/tables/ExportPdfTable/ExportPdfComponent.js
@@ -12,13 +12,13 @@ const ExportPdfComponent = (props) => {
     return (
         <div className="btnCompoWrap">
             <h3 className="btn-title">Export PDF Table</h3>
-            <ToggleView
-                onChange={(ev) =>
-                    ev === "react" ? setMatview(false) : setMatview(true)
-                }
-                isViewResized={props.isViewResized}
-            />
             <div className="step-tabs-wrapper">
+                <ToggleView
+                    onChange={(ev) =>
+                        ev === "react" ? setMatview(false) : setMatview(true)
+                    }
+                    isViewResized={props.isViewResized}
+                />
                 <Tabs defaultActiveKey="demo" id="code-demo-tab">
                     <Tab eventKey="demo" title="Demo">
                         {!matview ? <RbExportPdf /> : <MatExportPdf />}

--- a/src/components/tables/FilterTable/FilterTableComponent.js
+++ b/src/components/tables/FilterTable/FilterTableComponent.js
@@ -1,28 +1,28 @@
 import React, { useEffect, useState } from 'react';
 import ToggleView from '../../util/ToggleView';
 import { RbFilterTable, RbFilterTableCode } from './RbFilterTable'
-import {  MatFilterTable,  MatFilterTableCode } from './MatFilterTable';
+import { MatFilterTable, MatFilterTableCode } from './MatFilterTable';
 import Tabs from 'react-bootstrap/Tabs'
 import Tab from 'react-bootstrap/Tab';
 
-const FilterTableComponent = (props)=> {
-  const [ matview, setMatview ] = useState(false);
-  useEffect(()=> window.scrollTo(0,0));
+const FilterTableComponent = (props) => {
+  const [matview, setMatview] = useState(false);
+  useEffect(() => window.scrollTo(0, 0));
 
   return (
     <div className='btnCompoWrap'>
       <h3 className='btn-title'>Filter Table</h3>
-      <ToggleView 
-        onChange={(ev) => (ev === 'react') ? setMatview(false) : setMatview(true)}
-        isViewResized={props.isViewResized}
-      />
       <div className='step-tabs-wrapper'>
+        <ToggleView
+          onChange={(ev) => (ev === 'react') ? setMatview(false) : setMatview(true)}
+          isViewResized={props.isViewResized}
+        />
         <Tabs defaultActiveKey="demo" id="code-demo-tab">
           <Tab eventKey="demo" title="Demo">
-            {!matview ? <RbFilterTable/> : <MatFilterTable />}
+            {!matview ? <RbFilterTable /> : <MatFilterTable />}
           </Tab>
           <Tab eventKey="code" title="Code">
-            {!matview ? <RbFilterTableCode/> : <MatFilterTableCode/>}
+            {!matview ? <RbFilterTableCode /> : <MatFilterTableCode />}
           </Tab>
         </Tabs>
       </div>

--- a/src/components/tables/PaginationTable/PaginationTableComponent.js
+++ b/src/components/tables/PaginationTable/PaginationTableComponent.js
@@ -15,13 +15,13 @@ const PaginationTableComponent = (props) => {
   return (
     <div className="btnCompoWrap">
       <h3 className="btn-title">Pagination Table</h3>
-      <ToggleView
-        onChange={(ev) =>
-          ev === "react" ? setMatview(false) : setMatview(true)
-        }
-        isViewResized={props.isViewResized}
-      />
       <div className="step-tabs-wrapper">
+        <ToggleView
+          onChange={(ev) =>
+            ev === "react" ? setMatview(false) : setMatview(true)
+          }
+          isViewResized={props.isViewResized}
+        />
         <Tabs defaultActiveKey="demo" id="code-demo-tab">
           <Tab eventKey="demo" title="Demo">
             {!matview ? <RbPaginationTable /> : <MatPaginationTable />}

--- a/src/components/tables/SortableTable/SortableTableComponent.js
+++ b/src/components/tables/SortableTable/SortableTableComponent.js
@@ -15,13 +15,13 @@ const SortableTableComponent = (props) => {
   return (
     <div className="btnCompoWrap">
       <h3 className="btn-title">Sortable Table</h3>
-      <ToggleView
-        onChange={(ev) =>
-          ev === "react" ? setMatview(false) : setMatview(true)
-        }
-        isViewResized={props.isViewResized}
-      />
       <div className="step-tabs-wrapper">
+        <ToggleView
+          onChange={(ev) =>
+            ev === "react" ? setMatview(false) : setMatview(true)
+          }
+          isViewResized={props.isViewResized}
+        />
         <Tabs defaultActiveKey="demo" id="code-demo-tab">
           <Tab eventKey="demo" title="Demo">
             {!matview ? <RbSortableTable /> : <MatSortableTable />}

--- a/src/components/tables/Table/BasicTableComponent.js
+++ b/src/components/tables/Table/BasicTableComponent.js
@@ -1,28 +1,28 @@
 import React, { useEffect, useState } from 'react';
 import ToggleView from '../../util/ToggleView';
 import { RbBasicTable, RbBasicTableCode } from './RbBasicTable';
-import {  MatBasicTable,  MatBasicTableCode } from './MatBasicTable';
+import { MatBasicTable, MatBasicTableCode } from './MatBasicTable';
 import Tabs from 'react-bootstrap/Tabs'
 import Tab from 'react-bootstrap/Tab';
 
 function BasicTableComponent(props) {
-  const [ matview, setMatview ] = useState(false);
-  useEffect(()=> window.scrollTo(0,0));
+  const [matview, setMatview] = useState(false);
+  useEffect(() => window.scrollTo(0, 0));
 
   return (
     <div className='btnCompoWrap'>
       <h3 className='btn-title'>Basic Table</h3>
-      <ToggleView 
-        onChange={(ev) => (ev === 'react') ? setMatview(false) : setMatview(true)}
-        isViewResized={props.isViewResized}
-      />
       <div className='step-tabs-wrapper'>
+        <ToggleView
+          onChange={(ev) => (ev === 'react') ? setMatview(false) : setMatview(true)}
+          isViewResized={props.isViewResized}
+        />
         <Tabs defaultActiveKey="demo" id="code-demo-tab">
           <Tab eventKey="demo" title="Demo">
-            {!matview ? <RbBasicTable/> : <MatBasicTable />}
+            {!matview ? <RbBasicTable /> : <MatBasicTable />}
           </Tab>
           <Tab eventKey="code" title="Code">
-            {!matview ? <RbBasicTableCode/> : <MatBasicTableCode/>}
+            {!matview ? <RbBasicTableCode /> : <MatBasicTableCode />}
           </Tab>
         </Tabs>
       </div>

--- a/src/components/util/ToggleView.css
+++ b/src/components/util/ToggleView.css
@@ -1,7 +1,7 @@
 .toggle-demo-sec {
   position: absolute;
-  right: 6.19%;
-  top: 25%;
+  right: 8px;
+  top: 6px;
 }
 
 .toggleView-btn {
@@ -18,7 +18,8 @@
   border: 1px solid #d7d7d9;
   border-color: #d7d7d9 !important;
 }
-.toggleView-btn.active{
+
+.toggleView-btn.active {
   background-color: #ff9b21 !important;
   color: #fff !important;
   box-shadow: none !important;
@@ -29,15 +30,17 @@
   height: 31px;
   padding: 4.6px 0 6px;
   float: left;
-  line-height: inherit!important;
+  line-height: inherit !important;
   border: 1px solid #d7d7d9;
   border-color: #d7d7d9 !important;
 }
-.toggleView-btn.focus{
+
+.toggleView-btn.focus {
   outline: none !important;
   border-color: #d7d7d9 !important;
   box-shadow: none !important;
 }
+
 .toggleAdjust {
   position: absolute;
   right: 22%;

--- a/src/components/utility/Accordion/AccordionComponent.js
+++ b/src/components/utility/Accordion/AccordionComponent.js
@@ -6,23 +6,23 @@ import Tabs from 'react-bootstrap/Tabs'
 import Tab from 'react-bootstrap/Tab';
 
 function AccordionComponent(props) {
-  const [ matview, setMatview ] = useState(false);
-  useEffect(()=> window.scrollTo(0,0));
+  const [matview, setMatview] = useState(false);
+  useEffect(() => window.scrollTo(0, 0));
 
   return (
     <div className='btnCompoWrap'>
       <h3 className='btn-title'>Accordion</h3>
-      <ToggleView 
-        onChange={(ev) => (ev === 'react') ? setMatview(false) : setMatview(true)}
-        isViewResized={props.isViewResized}
-      />
       <div className='step-tabs-wrapper'>
+        <ToggleView
+          onChange={(ev) => (ev === 'react') ? setMatview(false) : setMatview(true)}
+          isViewResized={props.isViewResized}
+        />
         <Tabs defaultActiveKey="demo" id="code-demo-tab">
           <Tab eventKey="demo" title="Demo">
-            {!matview ? <RbAccordion/> : <MatAccordion/>}
+            {!matview ? <RbAccordion /> : <MatAccordion />}
           </Tab>
           <Tab eventKey="code" title="Code">
-            {!matview ? <RbAccordionCode/> : <MatAccordionCode/> }
+            {!matview ? <RbAccordionCode /> : <MatAccordionCode />}
           </Tab>
         </Tabs>
       </div>

--- a/src/components/utility/Alert/AlertComponent.js
+++ b/src/components/utility/Alert/AlertComponent.js
@@ -6,22 +6,22 @@ import Tabs from 'react-bootstrap/Tabs'
 import Tab from 'react-bootstrap/Tab';
 
 function AlertComponent(props) {
-  const [ matview, setMatview ] = useState(false);
-  useEffect(()=> window.scrollTo(0,0),[]);
+  const [matview, setMatview] = useState(false);
+  useEffect(() => window.scrollTo(0, 0), []);
   return (
     <div className='btnCompoWrap'>
       <h3 className='btn-title'>Alert</h3>
-      <ToggleView 
-        onChange={(ev) => (ev === 'react') ? setMatview(false) : setMatview(true)}
-        isViewResized={props.isViewResized}
-      />
       <div className='step-tabs-wrapper'>
+        <ToggleView
+          onChange={(ev) => (ev === 'react') ? setMatview(false) : setMatview(true)}
+          isViewResized={props.isViewResized}
+        />
         <Tabs defaultActiveKey="demo" id="code-demo-tab">
           <Tab eventKey="demo" title="Demo">
-            {!matview ? <RbAlert/> : <MatAlert/> }
+            {!matview ? <RbAlert /> : <MatAlert />}
           </Tab>
           <Tab eventKey="code" title="Code">
-            {!matview ? <RbAlertCode/> : <MatAlertCode></MatAlertCode>}
+            {!matview ? <RbAlertCode /> : <MatAlertCode></MatAlertCode>}
           </Tab>
         </Tabs>
       </div>

--- a/src/components/utility/Breadcrumbs/BreadcrumbsComponent.js
+++ b/src/components/utility/Breadcrumbs/BreadcrumbsComponent.js
@@ -6,23 +6,23 @@ import Tabs from 'react-bootstrap/Tabs'
 import Tab from 'react-bootstrap/Tab';
 
 function BreadcrumbsComponent(props) {
-  const [ matview, setMatview ] = useState(false);
-  useEffect(()=> window.scrollTo(0,0));
+  const [matview, setMatview] = useState(false);
+  useEffect(() => window.scrollTo(0, 0));
 
   return (
     <div className='btnCompoWrap'>
       <h3 className='btn-title'>Breadcrumbs</h3>
-      <ToggleView 
-        onChange={(ev) => (ev === 'react') ? setMatview(false) : setMatview(true)}
-        isViewResized={props.isViewResized}
-      />
       <div className='step-tabs-wrapper'>
+        <ToggleView
+          onChange={(ev) => (ev === 'react') ? setMatview(false) : setMatview(true)}
+          isViewResized={props.isViewResized}
+        />
         <Tabs defaultActiveKey="demo" id="code-demo-tab">
           <Tab eventKey="demo" title="Demo">
-            {!matview ? <RbBreadcrumbs/> : <MatBreadcrumbs/>}
+            {!matview ? <RbBreadcrumbs /> : <MatBreadcrumbs />}
           </Tab>
           <Tab eventKey="code" title="Code">
-            {!matview ? <RbBreadcrumbsCode/> : <MatBreadcrumbsCode/> }
+            {!matview ? <RbBreadcrumbsCode /> : <MatBreadcrumbsCode />}
           </Tab>
         </Tabs>
       </div>

--- a/src/components/utility/Cards/CardsComponent.js
+++ b/src/components/utility/Cards/CardsComponent.js
@@ -6,23 +6,23 @@ import Tabs from 'react-bootstrap/Tabs'
 import Tab from 'react-bootstrap/Tab';
 
 function CardsComponent(props) {
-  const [ matview, setMatview ] = useState(false);
-  useEffect(()=> window.scrollTo(0,0));
+  const [matview, setMatview] = useState(false);
+  useEffect(() => window.scrollTo(0, 0));
 
   return (
     <div className='btnCompoWrap'>
       <h3 className='btn-title'>Cards</h3>
-      <ToggleView 
-        onChange={(ev) => (ev === 'react') ? setMatview(false) : setMatview(true)}
-        isViewResized={props.isViewResized}
-      />
       <div className='step-tabs-wrapper'>
+        <ToggleView
+          onChange={(ev) => (ev === 'react') ? setMatview(false) : setMatview(true)}
+          isViewResized={props.isViewResized}
+        />
         <Tabs defaultActiveKey="demo" id="code-demo-tab">
           <Tab eventKey="demo" title="Demo">
-            {!matview ? <RbCards/> : <MatCards/>}
+            {!matview ? <RbCards /> : <MatCards />}
           </Tab>
           <Tab eventKey="code" title="Code">
-            {!matview ? <RbCardsCode/> : <MatCardsCode/> }
+            {!matview ? <RbCardsCode /> : <MatCardsCode />}
           </Tab>
         </Tabs>
       </div>

--- a/src/components/utility/Form/FormComponent.js
+++ b/src/components/utility/Form/FormComponent.js
@@ -1,28 +1,28 @@
 import React, { useEffect, useState } from 'react';
 import ToggleView from '../../util/ToggleView';
 import { RbForm, RbFormCode } from './RbForm'
-import {  MatForm,  MatFormCode } from './MatForm';
+import { MatForm, MatFormCode } from './MatForm';
 import Tabs from 'react-bootstrap/Tabs'
 import Tab from 'react-bootstrap/Tab';
 
-const FormComponent = (props)=> {
-  const [ matview, setMatview ] = useState(false);
-  useEffect(()=> window.scrollTo(0,0));
+const FormComponent = (props) => {
+  const [matview, setMatview] = useState(false);
+  useEffect(() => window.scrollTo(0, 0));
 
   return (
     <div className='btnCompoWrap'>
       <h3 className='btn-title'>Forms</h3>
-      <ToggleView 
-        onChange={(ev) => (ev === 'react') ? setMatview(false) : setMatview(true)}
-        isViewResized={props.isViewResized}
-      />
       <div className='step-tabs-wrapper'>
+        <ToggleView
+          onChange={(ev) => (ev === 'react') ? setMatview(false) : setMatview(true)}
+          isViewResized={props.isViewResized}
+        />
         <Tabs defaultActiveKey="demo" id="code-demo-tab">
           <Tab eventKey="demo" title="Demo">
-            {!matview ? <RbForm/> : <MatForm />}
+            {!matview ? <RbForm /> : <MatForm />}
           </Tab>
           <Tab eventKey="code" title="Code">
-            {!matview ? <RbFormCode/> : <MatFormCode/>}
+            {!matview ? <RbFormCode /> : <MatFormCode />}
           </Tab>
         </Tabs>
       </div>

--- a/src/components/utility/Pagination/PaginationComponent.js
+++ b/src/components/utility/Pagination/PaginationComponent.js
@@ -6,23 +6,23 @@ import Tabs from 'react-bootstrap/Tabs'
 import Tab from 'react-bootstrap/Tab';
 
 function PaginationComponent(props) {
-  const [ matview, setMatview ] = useState(false);
-  useEffect(()=> window.scrollTo(0,0));
+  const [matview, setMatview] = useState(false);
+  useEffect(() => window.scrollTo(0, 0));
 
   return (
     <div className='btnCompoWrap'>
       <h3 className='btn-title'>Pagination</h3>
-      <ToggleView 
-        onChange={(ev) => (ev === 'react') ? setMatview(false) : setMatview(true)}
-        isViewResized={props.isViewResized}
-      />
       <div className='step-tabs-wrapper'>
+        <ToggleView
+          onChange={(ev) => (ev === 'react') ? setMatview(false) : setMatview(true)}
+          isViewResized={props.isViewResized}
+        />
         <Tabs defaultActiveKey="demo" id="code-demo-tab">
           <Tab eventKey="demo" title="Demo">
-            {!matview ? <RbPagination/> : <MatPagination/>}
+            {!matview ? <RbPagination /> : <MatPagination />}
           </Tab>
           <Tab eventKey="code" title="Code">
-            {!matview ? <RbPaginationCode/> : <MatPaginationCode/> }
+            {!matview ? <RbPaginationCode /> : <MatPaginationCode />}
           </Tab>
         </Tabs>
       </div>

--- a/src/components/utility/Progress/ProgressComponent.js
+++ b/src/components/utility/Progress/ProgressComponent.js
@@ -6,23 +6,23 @@ import Tabs from 'react-bootstrap/Tabs'
 import Tab from 'react-bootstrap/Tab';
 
 function ProgressComponent(props) {
-  const [ matview, setMatview ] = useState(false);
-  useEffect(()=> window.scrollTo(0,0));
+  const [matview, setMatview] = useState(false);
+  useEffect(() => window.scrollTo(0, 0));
 
   return (
     <div className='btnCompoWrap'>
       <h3 className='btn-title'>Progress</h3>
-      <ToggleView 
-        onChange={(ev) => (ev === 'react') ? setMatview(false) : setMatview(true)}
-        isViewResized={props.isViewResized}
-      />
       <div className='step-tabs-wrapper'>
+        <ToggleView
+          onChange={(ev) => (ev === 'react') ? setMatview(false) : setMatview(true)}
+          isViewResized={props.isViewResized}
+        />
         <Tabs defaultActiveKey="demo" id="code-demo-tab">
           <Tab eventKey="demo" title="Demo">
-            {!matview ? <RbProgress/> : <MatProgress/>}
+            {!matview ? <RbProgress /> : <MatProgress />}
           </Tab>
           <Tab eventKey="code" title="Code">
-            {!matview ? <RbProgressCode/> : <MatProgressCode/> }
+            {!matview ? <RbProgressCode /> : <MatProgressCode />}
           </Tab>
         </Tabs>
       </div>

--- a/src/components/utility/Spinner/SpinnerComponent.js
+++ b/src/components/utility/Spinner/SpinnerComponent.js
@@ -1,27 +1,27 @@
 import React, { useEffect, useState } from 'react';
 import ToggleView from '../../util/ToggleView';
-import { RbSpinner, RbSpinnerCode} from './RbSpinner';
+import { RbSpinner, RbSpinnerCode } from './RbSpinner';
 import { MatSpinner, MatSpinnerCode } from './MatSpinner';
 import Tabs from 'react-bootstrap/Tabs'
 import Tab from 'react-bootstrap/Tab';
 
 function SpinnerComponent(props) {
-  const [ matview, setMatview ] = useState(false);
-  useEffect(()=> window.scrollTo(0,0), []);
+  const [matview, setMatview] = useState(false);
+  useEffect(() => window.scrollTo(0, 0), []);
   return (
     <div className='btnCompoWrap'>
       <h3 className='btn-title'>Spinner</h3>
-      <ToggleView 
-        onChange={(ev) => (ev === 'react') ? setMatview(false) : setMatview(true)}
-        isViewResized={props.isViewResized}
-        />
       <div className='step-tabs-wrapper'>
+        <ToggleView
+          onChange={(ev) => (ev === 'react') ? setMatview(false) : setMatview(true)}
+          isViewResized={props.isViewResized}
+        />
         <Tabs defaultActiveKey="demo" id="code-demo-tab">
           <Tab eventKey="demo" title="Demo">
-            {!matview ? <RbSpinner/> : <MatSpinner/>}
+            {!matview ? <RbSpinner /> : <MatSpinner />}
           </Tab>
           <Tab eventKey="code" title="Code">
-            {!matview ? <RbSpinnerCode/> : <MatSpinnerCode/>}
+            {!matview ? <RbSpinnerCode /> : <MatSpinnerCode />}
           </Tab>
         </Tabs>
       </div>

--- a/src/components/utility/Tabs/TabsComponent.js
+++ b/src/components/utility/Tabs/TabsComponent.js
@@ -1,4 +1,4 @@
-import React, { useState,useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import { RbTabs, RbTabsCode } from './RbTabs';
 import { MatTabs, MatTabsCode } from './MatTabs';
 import ToggleView from '../../util/ToggleView';
@@ -6,23 +6,23 @@ import Tabs from 'react-bootstrap/Tabs'
 import Tab from 'react-bootstrap/Tab';
 
 function TabsComponent(props) {
-  const [ matview, setMatview ] = useState(false);
-  useEffect(()=> window.scrollTo(0,0));
+  const [matview, setMatview] = useState(false);
+  useEffect(() => window.scrollTo(0, 0));
 
   return (
     <div className='btnCompoWrap'>
       <h3 className='btn-title'>Tabs</h3>
-      <ToggleView 
-        onChange={(ev) => (ev === 'react') ? setMatview(false) : setMatview(true)}
-        isViewResized={props.isViewResized}
-        />
       <div className='step-tabs-wrapper'>
+        <ToggleView
+          onChange={(ev) => (ev === 'react') ? setMatview(false) : setMatview(true)}
+          isViewResized={props.isViewResized}
+        />
         <Tabs defaultActiveKey="demo" id="code-demo-tab">
           <Tab eventKey="demo" title="Demo">
-            {!matview ? <RbTabs/> : <MatTabs/> }
+            {!matview ? <RbTabs /> : <MatTabs />}
           </Tab>
           <Tab eventKey="code" title="Code">
-            {!matview ? <RbTabsCode/> : <MatTabsCode/>}
+            {!matview ? <RbTabsCode /> : <MatTabsCode />}
           </Tab>
         </Tabs>
       </div>

--- a/src/components/utility/Toast/ToastComponent.js
+++ b/src/components/utility/Toast/ToastComponent.js
@@ -7,23 +7,23 @@ import Tab from 'react-bootstrap/Tab';
 
 
 function ToastComponent(props) {
-  const [ matview, setMatview ] = useState(false);
-  useEffect(()=> window.scrollTo(0,0), []);
+  const [matview, setMatview] = useState(false);
+  useEffect(() => window.scrollTo(0, 0), []);
 
   return (
     <div className='btnCompoWrap'>
       <h3 className='btn-title'>Toasts</h3>
-      <ToggleView 
-        onChange={(ev) => (ev === 'react') ? setMatview(false) : setMatview(true)}
-        isViewResized={props.isViewResized}
-      />
       <div className='step-tabs-wrapper'>
+        <ToggleView
+          onChange={(ev) => (ev === 'react') ? setMatview(false) : setMatview(true)}
+          isViewResized={props.isViewResized}
+        />
         <Tabs defaultActiveKey="demo" id="code-demo-tab">
           <Tab eventKey="demo" title="Demo">
-            { !matview ? <RbToast/> : <MatToast/> }
+            {!matview ? <RbToast /> : <MatToast />}
           </Tab>
           <Tab eventKey="code" title="Code">
-            { !matview ? <RbToastCode/> : <MatToastCode/> }
+            {!matview ? <RbToastCode /> : <MatToastCode />}
           </Tab>
         </Tabs>
       </div>


### PR DESCRIPTION
This PR contains the following change:

1. Fixed react/material toggle button position to be inside the component view (container), for all components.

Before:
<img width="960" alt="image" src="https://github.com/uipractice/ReactJSComponents/assets/119662486/2ce022c2-010c-46f5-9656-043de05ec6b8">

After:
<img width="960" alt="image" src="https://github.com/uipractice/ReactJSComponents/assets/119662486/aef169d4-4555-46af-9880-77912f691b8e">